### PR TITLE
Added Data Loading Pipeline via PyTorch

### DIFF
--- a/PythonCode/data_loader.py
+++ b/PythonCode/data_loader.py
@@ -1,17 +1,16 @@
-from PIL import Image
-from itertools import chain, groupby
-from operator import itemgetter
 import cv2
 import os
 import csv
 import glob
-import numpy as np
 import torch
-import pandas as pd
-from torch.utils.data import DataLoader, Subset
-from torchvision.datasets import ImageFolder
 import torchvision.transforms.v2 as transforms
+
+from itertools import chain, groupby
+from operator import itemgetter
+from torch.utils.data import DataLoader, Dataset
+from torchvision.datasets import ImageFolder
 from sklearn.model_selection import train_test_split
+
 
 CLASS_NAMES_PATH = "data/names.csv"
 TRAIN_ANNO_PATH = "data/anno_train.csv"
@@ -25,9 +24,10 @@ BBOX_CROP_MARGIN = 16
 BATCH_SIZE = 32
 
 
-class CarsSubset(Subset):
+class CarsSubset(Dataset):
     def __init__(self, dataset, indices, transform=None):
-        super().__init__(dataset, indices)
+        self.dataset = dataset
+        self.indices = indices
         self.transform = transform
 
     def __getitem__(self, idx):
@@ -38,6 +38,62 @@ class CarsSubset(Subset):
     
     def __len__(self):
         return len(self.indices)
+
+def create_dataloaders(train_dst_root=TRAIN_DST_ROOT, test_dst_root=TEST_DST_ROOT, 
+                       batch_size=BATCH_SIZE, target_size=TARGET_SIZE, val_split_size=0.2, 
+                       split_random_state=42):
+    train_val_data = ImageFolder(train_dst_root)
+    test_data = ImageFolder(test_dst_root)
+
+    train_indices, val_indices, _, _ = train_test_split(
+        range(len(train_val_data)), 
+        train_val_data.targets, 
+        stratify=train_val_data.targets, 
+        test_size=val_split_size, 
+        random_state=split_random_state
+    )
+
+    # Data Augmentation for training split
+    train_transforms = transforms.Compose([
+        transforms.CenterCrop(target_size), 
+        transforms.RandomHorizontalFlip(), 
+        transforms.RandomRotation(15), 
+        transforms.ColorJitter(brightness=.5, contrast=.2, saturation=.2, hue=.1), 
+        transforms.ToImage(), 
+        transforms.ToDtype(torch.float32, scale=False), 
+        transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
+    ])
+
+    # Data Augmentation for validation and test split
+    valid_test_transforms = transforms.Compose([
+        transforms.CenterCrop(target_size), 
+        transforms.ToImage(), 
+        transforms.ToDtype(torch.float32, scale=False), 
+        transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
+    ])
+
+    train_split = CarsSubset(train_val_data, train_indices, transform=train_transforms)
+    val_split = CarsSubset(train_val_data, val_indices, transform=valid_test_transforms)
+    test_split = CarsSubset(test_data, range(len(test_data)), transform=valid_test_transforms)
+
+    # Verifying length of splits
+    # print("After data splitting:")
+    # print(f"Size of training split: {len(train_split)}")
+    # print(f"Size of validation split: {len(val_split)}")
+    # print(f"Size of test split: {len(test_split)}")
+
+    # Output
+    # Size of training split: 6528
+    # Size of validation split: 1632
+    # Size of test split: 8064
+
+    dataloaders = {
+        "train": DataLoader(train_split, batch_size=batch_size, shuffle=True), 
+        "val": DataLoader(val_split, batch_size=batch_size, shuffle=True), 
+        "test": DataLoader(test_split, batch_size=batch_size, shuffle=True)
+    }
+
+    return dataloaders
 
 def crop_to_bbox(img, annotation):
     height, width = img.shape[:2]
@@ -95,65 +151,27 @@ def get_annotations(path):
 
     return sorted(annotations, key=itemgetter("class_id"))
 
-# Sample code to perform preprocessing steps
-# names = get_names(CLASS_NAMES_PATH)
-# train_annotations = get_annotations(TRAIN_ANNO_PATH)
-# test_annotations = get_annotations(TEST_ANNO_PATH)
+if __name__ == "__main__":
+    # Sample code to perform preprocessing steps
+    names = get_names(CLASS_NAMES_PATH)
+    train_annotations = get_annotations(TRAIN_ANNO_PATH)
+    test_annotations = get_annotations(TEST_ANNO_PATH)
 
-# preprocess_image(names, train_annotations, TRAIN_SRC_ROOT, TRAIN_DST_ROOT)
-# preprocess_image(names, test_annotations, TEST_SRC_ROOT, TEST_DST_ROOT)
+    preprocess_image(names, train_annotations, TRAIN_SRC_ROOT, TRAIN_DST_ROOT)
+    preprocess_image(names, test_annotations, TEST_SRC_ROOT, TEST_DST_ROOT)
 
-# Verifying processed data size
-print(f"Number of processed training samples: {len(glob.glob(TRAIN_DST_ROOT + "/**/*.jpg"))}")
-print(f"Number of processed test samples: {len(glob.glob(TEST_DST_ROOT + "/**/*.jpg"))}")
-print(f"Number of classes in processed training samples: {len(next(os.walk(TRAIN_DST_ROOT))[1])}")
-print(f"Number of classes in processed test samples: {len(next(os.walk(TEST_DST_ROOT))[1])}")
+    # Verifying processed data size
+    print("After preprocessing:")
+    print(f"Number of processed training samples: {len(glob.glob(TRAIN_DST_ROOT + "/**/*.jpg"))}")
+    print(f"Number of processed test samples: {len(glob.glob(TEST_DST_ROOT + "/**/*.jpg"))}")
+    print(f"Number of classes in processed training samples: {len(next(os.walk(TRAIN_DST_ROOT))[1])}")
+    print(f"Number of classes in processed test samples: {len(next(os.walk(TEST_DST_ROOT))[1])}\n")
 
-# Output
-# Number of processed training samples: 8144
-# Number of processed test samples: 8041
-# Number of classes in processed training samples: 196
-# Number of classes in processed test samples: 196
+    # Output
+    # Number of processed training samples: 8144
+    # Number of processed test samples: 8041
+    # Number of classes in processed training samples: 196
+    # Number of classes in processed test samples: 196
 
-train_val_data = ImageFolder(TRAIN_DST_ROOT)
-test_data = ImageFolder(TEST_DST_ROOT)
-
-train_indices, val_indices, _, _ = train_test_split(
-    range(len(train_val_data)), 
-    train_val_data.targets, 
-    stratify=train_val_data.targets, 
-    test_size=0.2, 
-    random_state=42
-)
-
-train_transforms = transforms.Compose([
-    transforms.CenterCrop(TARGET_SIZE), 
-    transforms.RandomHorizontalFlip(), 
-    transforms.RandomRotation(15), 
-    transforms.ColorJitter(brightness=.5, contrast=.2, saturation=.2, hue=.1), 
-    transforms.ToImage(), 
-    transforms.ToDtype(torch.float32, scale=False), 
-    transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
-])
-
-valid_test_transforms = transforms.Compose([
-    transforms.CenterCrop(TARGET_SIZE), 
-    transforms.ToImage(), 
-    transforms.ToDtype(torch.float32, scale=False), 
-    transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
-])
-
-train_split = CarsSubset(train_val_data, train_indices, transform=train_transforms)
-val_split = CarsSubset(train_val_data, val_indices, transform=valid_test_transforms)
-test_split = CarsSubset(test_data, range(len(test_data)), transform=valid_test_transforms)
-
-# Verifying length of splits
-print(len(train_split))
-print(len(val_split))
-print(len(test_split))
-
-dataloaders = {
-    "train": DataLoader(train_split, batch_size=BATCH_SIZE, shuffle=True), 
-    "val": DataLoader(val_split, batch_size=BATCH_SIZE, shuffle=True), 
-    "test": DataLoader(test_split, batch_size=BATCH_SIZE, shuffle=True)
-}
+    # Sample code to split data, perform data augmentation, and create data loaders
+    dataloaders = create_dataloaders()


### PR DESCRIPTION
- Added `create_dataloaders` for data splitting, data augmentation, and data loader creation
- Moved sample calls from the global scope into `main`
- (Processed) Images are loaded through `torchvision.datasets.ImageFolder`, from `data-processed/`
- Parameter batch size for `DataLoader` instances is added as a global constant